### PR TITLE
Add Jest unit tests for audio helpers

### DIFF
--- a/audioHelpers.js
+++ b/audioHelpers.js
@@ -1,0 +1,22 @@
+function pitchToColor(pitch) {
+  if (pitch === 0) return 'gray';
+  const noteNames = ['C', 'C#', 'D', 'D#', 'E', 'F', 'F#', 'G', 'G#', 'A', 'A#', 'B'];
+  const synestheticColors = {
+    'C': '#FF0000', 'C#': '#FF8000', 'D': '#FFFF00', 'D#': '#80FF00', 'E': '#00FF00',
+    'F': '#00FFFF', 'F#': '#0080FF', 'G': '#0000FF', 'G#': '#8000FF', 'A': '#FF00FF',
+    'A#': '#FF0080', 'B': '#804000'
+  };
+  const midiNote = Math.round(12 * Math.log2(pitch / 440) + 69);
+  const noteName = noteNames[(midiNote % 12 + 12) % 12];
+  return synestheticColors[noteName] || 'black';
+}
+
+function calculateVolume(buffer) {
+  let sum = 0;
+  for (let i = 0; i < buffer.length; i += 2) {
+    sum += buffer[i] * buffer[i];
+  }
+  return Math.sqrt(sum / (buffer.length / 2));
+}
+
+module.exports = { pitchToColor, calculateVolume };

--- a/package.json
+++ b/package.json
@@ -1,0 +1,10 @@
+{
+  "name": "instrument-practice-game",
+  "version": "1.0.0",
+  "devDependencies": {
+    "jest": "^29.0.0"
+  },
+  "scripts": {
+    "test": "jest"
+  }
+}

--- a/tests/calculateVolume.test.js
+++ b/tests/calculateVolume.test.js
@@ -1,0 +1,17 @@
+const { calculateVolume } = require('../audioHelpers');
+
+test('calculateVolume returns 0 for all zeros', () => {
+  expect(calculateVolume([0,0,0,0])).toBeCloseTo(0);
+});
+
+test('calculateVolume handles constant positive ones', () => {
+  expect(calculateVolume([1,1,1,1])).toBeCloseTo(1);
+});
+
+test('calculateVolume handles alternating positive and negative ones', () => {
+  expect(calculateVolume([1,0,-1,0])).toBeCloseTo(1);
+});
+
+test('calculateVolume handles fractional values', () => {
+  expect(calculateVolume([0.5,0.5,0.5,0.5])).toBeCloseTo(0.5);
+});

--- a/tests/pitchToColor.test.js
+++ b/tests/pitchToColor.test.js
@@ -1,0 +1,20 @@
+const { pitchToColor } = require('../audioHelpers');
+
+test('pitchToColor returns gray for pitch 0', () => {
+  expect(pitchToColor(0)).toBe('gray');
+});
+
+test('pitchToColor returns correct colors for standard pitches', () => {
+  expect(pitchToColor(261.63)).toBe('#FF0000'); // C4
+  expect(pitchToColor(277.18)).toBe('#FF8000'); // C#4
+  expect(pitchToColor(293.66)).toBe('#FFFF00'); // D4
+  expect(pitchToColor(311.13)).toBe('#80FF00'); // D#4
+  expect(pitchToColor(329.63)).toBe('#00FF00'); // E4
+  expect(pitchToColor(349.23)).toBe('#00FFFF'); // F4
+  expect(pitchToColor(369.99)).toBe('#0080FF'); // F#4
+  expect(pitchToColor(392.00)).toBe('#0000FF'); // G4
+  expect(pitchToColor(415.30)).toBe('#8000FF'); // G#4
+  expect(pitchToColor(440.00)).toBe('#FF00FF'); // A4
+  expect(pitchToColor(466.16)).toBe('#FF0080'); // A#4
+  expect(pitchToColor(493.88)).toBe('#804000'); // B4
+});


### PR DESCRIPTION
## Summary
- set up `package.json` with Jest dev dependency
- add `audioHelpers.js` exporting helper functions
- write Jest tests for `pitchToColor` and `calculateVolume`

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_684973aeb5a8832e8e4b39733a885563