### PR TITLE
fix: prevent metronome errors when stopped

### DIFF
--- a/index.html
+++ b/index.html
@@ -171,6 +171,7 @@
     };
 
     function updateMetronome() {
+      if (!audioContext) return;
       if (metronomeInterval) {
         clearInterval(metronomeInterval);
         metronomeInterval = null;


### PR DESCRIPTION
## Summary
- guard `updateMetronome` when audio context is closed

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_684973a9390c832ea54cb65508a1aadd